### PR TITLE
Added support for using the QF_ABV fragment in the STP backend

### DIFF
--- a/src/metaSMT/backend/STP.hpp
+++ b/src/metaSMT/backend/STP.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../tags/QF_BV.hpp"
+#include "../tags/Array.hpp"
 #include "../result_wrapper.hpp"
 
 extern "C" {
@@ -16,6 +17,7 @@ namespace metaSMT {
   namespace solver {
     namespace predtags = ::metaSMT::logic::tag;
     namespace bvtags = ::metaSMT::logic::QF_BV::tag;
+    namespace arraytags = ::metaSMT::logic::Array::tag;
 
     /**
      * @ingroup Backend
@@ -345,6 +347,40 @@ namespace metaSMT {
                              , result_type b) {
         return ptr(vc_notExpr(vc, operator()(predtags::equal_tag(), a, b)));
       }
+      
+    
+      result_type operator() (arraytags::array_var_tag const & var
+                              , boost::any args )
+      {
+        if (var.id == 0 ) {
+          throw std::runtime_error("uninitialized array used");
+        }
+       
+        Type index_sort = vc_bvType(vc, var.index_width);
+        Type elem_sort = vc_bvType(vc, var.elem_width);
+        Type ty = vc_arrayType(vc, index_sort, elem_sort);
+
+        char buf[64];
+        sprintf(buf, "var_%u", var.id);
+	
+        return(ptr(vc_varExpr(vc, buf, ty)));	
+
+      }
+
+      
+      result_type operator() (arraytags::select_tag const &
+                              , result_type array
+                              , result_type index) {
+        return ptr(vc_readExpr(vc, array, index));
+      }
+
+      result_type operator() (arraytags::store_tag const &
+                              , result_type array
+                              , result_type index
+                              , result_type value) {
+        return ptr(vc_writeExpr(vc, array, index, value));
+      }
+      
 
       ////////////////////////
       // Fallback operators //


### PR DESCRIPTION
Dear metaSMT team,

I have been trying to add support in KLEE for using a number of SMT solvers via metaSMT. Cristian Cadar and I had a paper about that at CAV 2013 (http://srg.doc.ic.ac.uk/publications/klee-multisolver-cav-13.html), and I am now integrating the code into mainline KLEE. I had once sent you this patch that enables reasoning about arrays in the STP backend, but now that we started using github as well, it would be much easier if I just issue a pull request. It would be great if you apply the patch because otherwise we would need to supply it separately somewhere and ask users to apply it manually after obtaining the latest version of metaSMT. Please let me know what you think about that and whether you would like any modifications of the patch.

Thank you and best regards,
Hristina
