### PR TITLE
use boost::atomic_uint for new_variable

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ SRC_DIR=$( cd $(dirname $0) && pwd)
 
 BUILD_DIR=$PWD/build
 
-BOOST=boost-1_52_0
+BOOST=boost-1_55_0
 
 REQUIRES="
   $BOOST

--- a/src/lib/_var_id.cpp
+++ b/src/lib/_var_id.cpp
@@ -1,10 +1,12 @@
 #include "../metaSMT/impl/_var_id.hpp"
 
+#include <boost/atomic.hpp>
+
 namespace metaSMT {
   namespace impl {
       unsigned new_var_id(  )
       {
-        static unsigned _id = 0;
+        static boost::atomic_uint _id ( 0u );
         ++_id;
         return _id;
       } 


### PR DESCRIPTION
- minimum synchronization for developers that uses multi-threading
  while using a separate thread for each solver. However, at least
  the variables need to be synchronized.
  
  Furthermore, boost-1.52 had some problems with atomic and our g++ version.
  Boost version 1.55 is the lowest required version to fix that problem.
