### PR TITLE
Refactor array test

### DIFF
--- a/src/metaSMT/support/array_equal.hpp
+++ b/src/metaSMT/support/array_equal.hpp
@@ -1,0 +1,114 @@
+#pragma once
+#include "../API/Evaluator.hpp"
+#include "../frontend/QF_BV.hpp"
+#include "../frontend/Array.hpp"
+
+namespace metaSMT {
+  namespace support {
+
+    template < typename Lhs, typename Rhs >
+    struct ArrayEqualBase
+    {
+      ArrayEqualBase( Lhs lhs, Rhs rhs, unsigned index_width )
+        : lhs_(lhs)
+        , rhs_(rhs)
+        , index_width_(index_width)
+      {
+
+      }
+
+      Lhs lhs_;
+      Rhs rhs_;
+      unsigned index_width_;
+    };
+
+    template < typename Lhs, typename Rhs >
+    struct ArrayEqual : ArrayEqualBase<Lhs, Rhs>
+    {
+      ArrayEqual( Lhs lhs, Rhs rhs, unsigned index_width )
+        : ArrayEqualBase<Lhs, Rhs>(lhs, rhs, index_width)
+      {
+      }
+    };
+
+    template < typename Lhs, typename Rhs >
+    struct ArrayNequal : ArrayEqualBase<Lhs, Rhs>
+    {
+      ArrayNequal( Lhs lhs, Rhs rhs, unsigned index_width )
+        : ArrayEqualBase<Lhs, Rhs>(lhs, rhs, index_width)
+      {
+      }
+    };
+
+    template < typename Lhs, typename Rhs >
+    ArrayEqual<Lhs, Rhs> array_equal( Lhs lhs, Rhs rhs, unsigned index_width )
+    {
+      return ArrayEqual<Lhs, Rhs>( lhs, rhs, index_width);
+    }
+
+    template < typename Lhs, typename Rhs >
+    ArrayNequal<Lhs, Rhs> array_nequal( Lhs lhs, Rhs rhs, unsigned index_width )
+    {
+      return ArrayNequal<Lhs, Rhs>( lhs, rhs, index_width );
+    }
+
+  } // support
+
+  template < typename Lhs, typename Rhs >
+  struct Evaluator< support::ArrayEqual<Lhs, Rhs> > : public boost::mpl::true_ {
+
+    template < typename Context >
+    static typename Context::result_type
+    eval(Context &ctx, support::ArrayEqual<Lhs, Rhs> const &c)
+    {
+      using namespace logic;
+      using namespace logic::QF_BV;
+      using namespace logic::Array;
+
+      const unsigned width = c.index_width_;
+      unsigned long index_limit = 1ul << width;
+
+      typename Context::result_type result = evaluate( ctx, True );
+
+      for ( unsigned long index = 0; index < index_limit; ++index ) {
+        result = evaluate( ctx, And( result,
+	  equal(
+	    select( c.lhs_, bvuint(index, width) ),
+	    select( c.rhs_, bvuint(index, width) )
+	  ))
+        );
+      }
+
+      return result;
+    }
+  };
+
+  template < typename Lhs, typename Rhs >
+  struct Evaluator< support::ArrayNequal<Lhs, Rhs> > : public boost::mpl::true_ {
+
+    template < typename Context >
+    static typename Context::result_type
+    eval(Context &ctx, support::ArrayNequal<Lhs, Rhs> const &c)
+    {
+      using namespace logic;
+      using namespace logic::QF_BV;
+      using namespace logic::Array;
+
+      const unsigned width = c.index_width_;
+      unsigned long index_limit = 1ul << width;
+
+      typename Context::result_type result = evaluate( ctx, False );
+
+      for ( unsigned long index = 0; index < index_limit; ++index ) {
+        result = evaluate( ctx, Or( result,
+	  nequal(
+	    select( c.lhs_, bvuint(index, width) ),
+	    select( c.rhs_, bvuint(index, width) )
+	  ))
+        );
+      }
+
+      return result;
+    }
+  };
+} // metaSMT

--- a/tests/test_Array.cpp
+++ b/tests/test_Array.cpp
@@ -1,7 +1,7 @@
+#include <metaSMT/support/array_equal.hpp>
 #include <metaSMT/frontend/Array.hpp>
 #include <metaSMT/frontend/QF_BV.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/dynamic_bitset.hpp>
 #include <string>
 
 using namespace std;
@@ -9,13 +9,13 @@ using namespace metaSMT;
 using namespace metaSMT::logic;
 using namespace metaSMT::logic::Array;
 using namespace metaSMT::logic::QF_BV;
-namespace proto = boost::proto;
-using boost::dynamic_bitset;
+using metaSMT::support::array_equal;
+using metaSMT::support::array_nequal;
 
 
 BOOST_FIXTURE_TEST_SUITE(Array, Solver_Fixture )
 
-BOOST_AUTO_TEST_CASE( variable_equality )
+BOOST_AUTO_TEST_CASE( can_compare_array_variables_for_equality )
 {
   unsigned const elem_width = 8;
   unsigned const index_width = 4;
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE( variable_equality )
   BOOST_CHECK( !cmp );
 }
 
-BOOST_AUTO_TEST_CASE( array_equal_t ) {
+BOOST_AUTO_TEST_CASE( supports_exensibilty_with_equality_of_arrays ) {
   unsigned const elem_width = 8;
   unsigned const index_width = 4;
 
@@ -51,6 +51,17 @@ BOOST_AUTO_TEST_CASE( array_equal_t ) {
   BOOST_REQUIRE( !solve(ctx) );
 }
 
+BOOST_AUTO_TEST_CASE( supports_array_equal_helper ) {
+  unsigned const elem_width = 8;
+  unsigned const index_width = 4;
+
+  array a = new_array(elem_width, index_width);
+  array b = new_array(elem_width, index_width);
+
+  assumption( ctx, array_equal(a, b, index_width) );
+  BOOST_REQUIRE( solve(ctx) );
+}
+
 BOOST_AUTO_TEST_CASE( store_t ) {
   unsigned const elem_width = 8;
   unsigned const index_width = 4;
@@ -65,23 +76,23 @@ BOOST_AUTO_TEST_CASE( store_t ) {
   bitvector i = new_bitvector(index_width);
   bitvector j = new_bitvector(index_width);
 
-  assumption( ctx, equal(store(a, i, e), store(a, i, e)) );
+  assumption( ctx, array_equal(store(a, i, e), store(a, i, e), index_width) );
   BOOST_REQUIRE( solve(ctx) );
 
-  assumption( ctx, equal(a, b) );
-  assumption( ctx, equal(store(a, i, e), store(b, i, e)) );
+  assumption( ctx, array_equal(a, b, index_width) );
+  assumption( ctx, array_equal(store(a, i, e), store(b, i, e), index_width) );
   BOOST_REQUIRE( solve(ctx) );
 
-  assumption( ctx, equal(a, b) );
-  assumption( ctx, nequal(store(a, i, e), store(b, i, e)) );
+  assumption( ctx, array_equal(a, b, index_width) );
+  assumption( ctx, array_nequal(store(a, i, e), store(b, i, e), index_width) );
   BOOST_REQUIRE( !solve(ctx) );
 
   assumption( ctx, equal(i, j) );
-  assumption( ctx, equal(store(a, i, e), store(a, j, e)) );
+  assumption( ctx, array_equal(store(a, i, e), store(a, j, e), index_width) );
   BOOST_REQUIRE( solve(ctx) );
 
   assumption( ctx, equal(i, j) );
-  assumption( ctx, nequal(store(a, i, e), store(a, j, e)) );
+  assumption( ctx, array_nequal(store(a, i, e), store(a, j, e), index_width) );
   BOOST_REQUIRE( !solve(ctx) );  
 }
 
@@ -102,15 +113,15 @@ BOOST_AUTO_TEST_CASE( select_t ) {
   assumption( ctx, equal(select(a, i), select(a, i)) );
   BOOST_REQUIRE( solve(ctx) );
 
-  assumption( ctx, equal(a, b) );
+  assumption( ctx, array_equal(a, b, index_width) );
   assumption( ctx, equal(select(a, i), select(b, i)) );
   BOOST_REQUIRE( solve(ctx) );
 
-  assumption( ctx, equal(a, b) );
+  assumption( ctx, array_equal(a, b, index_width) );
   assumption( ctx, nequal(select(a, i), select(b, i)) );
   BOOST_REQUIRE( !solve(ctx) );
 
-  assumption( ctx, nequal(a, b) );
+  assumption( ctx, array_nequal(a, b, index_width) );
   assumption( ctx, nequal(select(a, i), select(b, i)) );
   BOOST_REQUIRE( solve(ctx) );
 


### PR DESCRIPTION
The array tests used `equal` and `nequal`, however this is not allowed by SMT2 standard.
Only very few solvers support it.
